### PR TITLE
Call function instead of method in global flag counting.

### DIFF
--- a/command.go
+++ b/command.go
@@ -144,7 +144,7 @@ func ParseAndRun() {
 
 // Returns the total number of globally registered flags.
 func numOfGlobalFlags() (count int) {
-	flag.CommandLine.VisitAll(func(flag *flag.Flag) {
+	flag.VisitAll(func(flag *flag.Flag) {
 		count++
 	})
 	return


### PR DESCRIPTION
Allows lib to work in older versions of Go.  Tests fail in older versions, but not sure how important that is too fix.
