### PR TITLE
Allow required arguments for subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ func (cmd *VersionCommand) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *VersionCommand) Run(args []string) {
 	// implement the main body of the subcommand here
+  // required and optional arguments are found in args
 }
 
 // register version as a subcommand
-command.On("version", "prints the version", &VersionCommand{})
-command.On("command1", "some description about command1", ...)
-command.On("command2", "some description about command2", ...)
+command.On("version", "prints the version", &VersionCommand{}, []string{"<required-arg>"})
+command.On("command1", "some description about command1", ..., []string{})
+command.On("command2", "some description about command2", ..., []string{})
 command.Parse()
 // ...
 command.Run()
@@ -60,10 +61,10 @@ command.Run()
 The program above will handle the registered commands and invoke the matching command's `Run` or print subcommand help if `-h` is set.
 
 ~~~
-$ program -exec-path=/home/user/bin/someexec version -v=true
+$ program -exec-path=/home/user/bin/someexec version -v=true history
 ~~~
 
-will out the version of the program in a verbose way, and will set the exec path to the provided path. If arguments doesn't match any subcommand or illegal arguments are provided, it will print the usage guide.
+will output the version of the program in a verbose way requring an argument (history), and will set the exec path to the provided path. If arguments doesn't match any subcommand or illegal arguments are provided, it will print the usage guide.
 
 
 ## License

--- a/command.go
+++ b/command.go
@@ -73,7 +73,7 @@ func Usage() {
 	fmt.Fprintf(os.Stderr, "Usage: %s <command>\n\n", program)
 	fmt.Fprintf(os.Stderr, "where <command> is one of:\n")
 	for name, cont := range cmds {
-		fmt.Fprintf(os.Stderr, "  %s\t%s\n", name, cont.desc)
+		fmt.Fprintf(os.Stderr, "  %-15s %s\n", name, cont.desc)
 	}
 
 	if numOfGlobalFlags() > 0 {

--- a/command.go
+++ b/command.go
@@ -45,18 +45,20 @@ type Cmd interface {
 }
 
 type cmdCont struct {
-	name    string
-	desc    string
-	command Cmd
+	name         string
+	desc         string
+	command      Cmd
+	requiredArgs []string
 }
 
 // Registers a Cmd for the provided sub-command name. E.g. name is the
 // `status` in `git status`.
-func On(name, description string, command Cmd) {
+func On(name, description string, command Cmd, reqArgs []string) {
 	cmds[name] = &cmdCont{
-		name:    name,
-		desc:    description,
-		command: command,
+		name:         name,
+		desc:         description,
+		command:      command,
+		requiredArgs: reqArgs,
 	}
 }
 
@@ -88,6 +90,13 @@ func subcommandUsage(cont *cmdCont) {
 	// should only output sub command flags, ignore h flag.
 	fs := matchingCmd.command.Flags(flag.NewFlagSet(cont.name, flag.ContinueOnError))
 	fs.PrintDefaults()
+	if len(cont.requiredArgs) > 0 {
+		fmt.Fprintf(os.Stderr, "\nArguments:\n\n")
+		for _, a := range cont.requiredArgs {
+			fmt.Fprintf(os.Stderr, "  %s\n", a)
+		}
+		fmt.Fprintf(os.Stderr, "\n")
+	}
 }
 
 // Parses the flags and leftover arguments to match them with a
@@ -117,6 +126,9 @@ func Parse() {
 		flagHelp = fs.Bool("h", false, "")
 		fs.Parse(flag.Args()[1:])
 		args = fs.Args()
+		if len(args) < len(cont.requiredArgs) {
+			*flagHelp = true
+		}
 		matchingCmd = cont
 	} else {
 		flag.Usage()

--- a/command_test.go
+++ b/command_test.go
@@ -63,7 +63,7 @@ func TestCommand(t *testing.T) {
 
 	flagGlobal1 := flag.String("global1", "default-global1", "Description about global1")
 	c1 := &testCmd1{}
-	On("command1", "", c1)
+	On("command1", "", c1, []string{})
 	Parse()
 	Run()
 	if !c1.run {
@@ -83,7 +83,7 @@ func TestCommandFlags(t *testing.T) {
 
 	flag.String("global1", "default-global1", "Description about global1")
 	c1 := &testCmd1{}
-	On("command1", "", c1)
+	On("command1", "", c1, []string{})
 	Parse()
 	Run()
 	if !c1.run {
@@ -101,8 +101,8 @@ func TestMultiCommands(t *testing.T) {
 
 	c1 := &testCmd1{}
 	c2 := &testCmd2{}
-	On("command1", "", c1)
-	On("command2", "", c2)
+	On("command1", "", c1, []string{})
+	On("command2", "", c2, []string{})
 	Parse()
 	Run()
 	if c1.run {
@@ -118,7 +118,7 @@ func TestRun(t *testing.T) {
 	resetForTesting("command1")
 
 	c1 := &testCmd1{}
-	On("command1", "", c1)
+	On("command1", "", c1, []string{})
 	Parse()
 	if c1.run {
 		t.Error("command 'command1' was not expected to run, but it did")
@@ -129,10 +129,21 @@ func TestAdditionalCommandArgs(t *testing.T) {
 	resetForTesting("command1", "--flag1=true", "somearg")
 
 	c1 := &testCmd1{}
-	On("command1", "", c1)
+	On("command1", "", c1, []string{})
 	Parse()
 	if len(args) < 1 || args[0] != "somearg" {
 		t.Error("additional command 'somearg' is expected, but can't be found")
+	}
+}
+
+func TestAdditionalCommandAsRequiredArgs(t *testing.T) {
+	resetForTesting("command1", "--flag1=true", "somearg")
+
+	c1 := &testCmd1{}
+	On("command1", "", c1, []string{"<arg>", "<another-arg>"})
+	Parse()
+	if *flagHelp != true {
+		t.Error("expecting flagHelp to be true")
 	}
 }
 


### PR DESCRIPTION
Simple enforcement that additional arguments are passed to a subcommand.  If they are not then the subcommand's usage is displayed.

```
command.On("subcommand", "prints the version", &SubCommand{}, []string{"<requiredArg1>", "<requiredArg2"})

$ program -mainflags subcommand -subflags requiredArg1 requiredArg2
```

```
command.On("version", "prints the version", &VersionCommand{}, []string{"<detail-level>"})

$ program version full
```
- BC break in On() function.
- Arguments are fetched in cmd.Run() the same way as today (and there is no reference to the text passed to On() - that is currently used in usage output)
- Addition of more whitespace is usage output
