### PR TITLE
added a Commander to allow sub command nesting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: go
-go: 1.2
+go:
+  - 1.2
+  - 1.3
+  - tip

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See [compgen package](https://github.com/ericaro/compgen) for more details.
     }
 
     // create and add a "commander"
-    remote := command.NewCommander()
+    remote := command.New()
     command.On("remote", "<command>", "remote subcommands", remote)
     // and configure it
     remote.On("add", "<url>", "add a remote by url", adderCmd{})

--- a/README.md
+++ b/README.md
@@ -1,70 +1,107 @@
-# command
+[![Build Status](https://travis-ci.org/ericaro/command.png?branch=master)](https://travis-ci.org/ericaro/command) [![GoDoc](https://godoc.org/github.com/ericaro/command?status.svg)](https://godoc.org/github.com/ericaro/command)
 
-[![Build Status](https://travis-ci.org/rakyll/command.png?branch=master)](https://travis-ci.org/rakyll/command)
+This library is fully `go gettable`.
 
 command is a tiny package that helps you to add cli subcommands to your Go program with no effort, and prints a pretty guide if needed.
 
-~~~
-Usage: program <command>
 
-where <command> is one of:
-  version   prints the version
-  command1  some description about command1
-  command2  some description about command2
+This work is a derivative of [rakyll's](https://github.com/rakyll/command) command library.
 
-available flags:
-  -exec-path="": a custom path to executable
-
-program <command> -h for subcommand help
-~~~
+Mainly to make it:
+- **Modular**: flags, completion, recursion are all optionals
+- **Recursive**: commands can have subcommands and so on 
+- **autocompletion**: mode compatible with bash completion
 
 ## Usage
 
-In order to start, go get this repository:
+get go an `go get`
 
 ~~~ sh
-go get github.com/rakyll/command
+go get github.com/ericaro/command
 ~~~
 
-This package allows you to use flags package as you used to do, and provides additional parsing for subcommands and subcommand flags.
+
+### Simplest commands
 
 ~~~ go
-import "github.com/rakyll/command"
 
-// register any global flags
-var flagExecPath = flag.String("exec-path", "", "a custom path to executable")
+    import "github.com/ericaro/command"
+     
+     type VersionCommand struct{}
+     
+     func (cmd *VersionCommand) Run(args []string) {
+       // implement the main body of the subcommand here
+       // arguments are found in args
+     }
+     
+     
+     // register version as a subcommand
+     command.On("version", "", prints the version", &VersionCommand{})
+     command.On("command1","[-option] <arguments>", "some description about command1")   
+     command.On("command2","[-option] <arguments>", "some description about command2")
+     // ...
+     command.Run()
+~~~
+
+That's it. It works.
+
+### Adding autocompletion
+
+See [compgen package](https://github.com/ericaro/compgen) for more details.
+
+When using `command` executable are builtin with completion capability. So you just need to register them as their own completion command:
+
+~~~ bash
+$ complete -C cmd cmd
+~~~
+
+You can copy this statement in a file into `/etc/bash_completion.d/` to make it persistent.
+
+By default completion works with
+- subcommands
+- flags names
+- flags default value
+
+It is possible though to configure it (see below)
+
+### Adding flags
+
+~~~ go
 
 type VersionCommand struct{
-	flagVerbose *bool
+  flagVerbose *bool
 }
 
-func (cmd *VersionCommand) Flags(fs *flag.FlagSet) *flag.FlagSet {
-	// define subcommand's flags
-	cmd.flagVerbose = fs.Bool("v", false, "provides verbose output")
-	return fs
+func (cmd *VersionCommand) Flags(fs *flag.FlagSet) {
+  // define subcommand's flags
+  cmd.flagVerbose = fs.Bool("v", false, "provides verbose output")
 }
 
-func (cmd *VersionCommand) Run(args []string) {
-	// implement the main body of the subcommand here
-  // required and optional arguments are found in args
-}
-
-// register version as a subcommand
-command.On("version", "prints the version", &VersionCommand{}, []string{"<required-arg>"})
-command.On("command1", "some description about command1", ..., []string{})
-command.On("command2", "some description about command2", ..., []string{})
-command.Parse()
-// ...
-command.Run()
-~~~
-
-The program above will handle the registered commands and invoke the matching command's `Run` or print subcommand help if `-h` is set.
+// everything else is unchanged
 
 ~~~
-$ program -exec-path=/home/user/bin/someexec version -v=true history
+
+### Hacking autocomplete
+
+Commands come with a default support for completion (see above)
+
+It is possible to hack in:
+
+~~~ go
+
+    type VersionCommand struct{}
+    
+    func (cmd *VersionCommand) Compgens(term *compgen.Terminator) {
+      term.Flag("d", compgen.CompgenCmd("directory") )
+    }
+    
+    // everything else is unchanged
+
 ~~~
 
-will output the version of the program in a verbose way requring an argument (history), and will set the exec path to the provided path. If arguments doesn't match any subcommand or illegal arguments are provided, it will print the usage guide.
+Now the "-d" flag will be auto-completed with local directories.
+
+See [compgen package](https://github.com/ericaro/compgen) for more details.
 
 
 ## License

--- a/command.go
+++ b/command.go
@@ -20,59 +20,46 @@ package command
 import (
 	"flag"
 	"os"
+
+	"github.com/ericaro/compgen"
 )
 
 //CommandLine is the replacement for all variables see commander for implementation
 
-// CommandLine is the default commander.
+// CommandLine is the default Commander.
 // The top-level functions such as On, Usage, Parse and so on are wrappers for the
 // methods of CommandLine.
-var CommandLine = NewCommander(os.Args[0], flag.CommandLine)
+var CommandLine = NewCommander()
 
-// Cmd represents a sub command, allowing to define subcommand
-// flags and runnable to run once arguments match the subcommand
-// requirements.
+// Cmd represents a sub command, the simplest subcommands on have to implement this interface
 type Cmd interface {
-	Flags(*flag.FlagSet) *flag.FlagSet
 	Run(args []string)
 }
 
+//Flagger is the interface that defines the Flag methods that allow to configure flags
+type Flagger interface {
+	Flags(*flag.FlagSet)
+}
+
+//Completer is the interface that defines the Compgens methods that allow to configure a Terminator
+type Completer interface {
+	Compgens(*compgen.Terminator)
+}
+
+// simple command container
 type cmdCont struct {
-	name          string
-	desc          string
-	command       Cmd
-	requiredFlags []string
+	name, syntax, description string
+	command                   Cmd
 }
 
 // Registers a Cmd for the provided sub-command name. E.g. name is the
 // `status` in `git status`.
-func On(name, description string, command Cmd, requiredFlags []string) {
-	CommandLine.On(name, description, command, requiredFlags)
-}
-
-// Prints the usage.
-func Usage() {
-	CommandLine.Usage()
-}
-
-// Parses the flags and leftover arguments to match them with a
-// sub-command. Evaluate all of the global flags and register
-// sub-command handlers before calling it. Sub-command handler's
-// `Run` will be called if there is a match.
-// A usage with flag defaults will be printed if provided arguments
-// don't match the configuration.
-// Global flags are accessible once Parse executes.
-func Parse() {
-	flag.Parse() // the recursive definition of Commander requires that the command flag is parsed before calling Parse()
-	CommandLine.Parse()
+func On(name, syntax, description string, command Cmd) {
+	CommandLine.On(name, syntax, description, command)
 }
 
 // Runs the subcommand's runnable. If there is no subcommand
 // registered, it silently returns.
-func Run() { CommandLine.Run(nil) }
-
-// Parses flags and run's matching subcommand's runnable.
-func ParseAndRun() {
-	Parse()
-	Run()
+func Run() {
+	Launch(CommandLine, os.Args[0], os.Args)
 }

--- a/command.go
+++ b/command.go
@@ -27,11 +27,10 @@ import (
 //CommandLine is the replacement for all variables see commander for implementation
 
 // CommandLine is the default Commander.
-// The top-level functions such as On, Usage, Parse and so on are wrappers for the
-// methods of CommandLine.
+// The top-level functions On and  Run are wrapper around this var
 var CommandLine = New()
 
-// Cmd represents a sub command, the simplest subcommands on have to implement this interface
+// Cmd represents a sub command
 type Cmd interface {
 	Run(args []string)
 }
@@ -55,12 +54,10 @@ type Completer interface {
 // - Run the matching subcommand
 //
 type Commander interface {
-	Cmd             // run a command
+	Cmd
 	Flagger         //configure flags
 	Completer       // configure a terminator
 	compgen.Argsgen //ability to complete var args
-	// Registers a Cmd for the provided sub-command name. E.g. name is the
-	// `status` in `git status`.
 	On(name, syntax, description string, command Cmd)
 	Path(qname string)
 }

--- a/command_test.go
+++ b/command_test.go
@@ -73,7 +73,7 @@ func resetForTesting(args ...string) {
 
 	os.Args = append([]string{"cmd"}, args...)
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	CommandLine = NewCommander()
+	CommandLine = New()
 }
 
 // testCmd1 is a test sub command.

--- a/command_test.go
+++ b/command_test.go
@@ -20,51 +20,12 @@ import (
 	"testing"
 )
 
-// Tests if global flags default values are set if there are
-// no flags provided.
-func TestDefaultGlobalFlags(t *testing.T) {
-	resetForTesting()
-
-	flagGlobal1 := flag.String("global1", "default-global1", "Description about global1")
-	Parse()
-	if *flagGlobal1 != "default-global1" {
-		t.Error("global flag should be set to default val if the flag is not set")
-	}
-}
-
-// Tests if global flags are set if they are provided by the user.
-func TestGlobalFlags(t *testing.T) {
-	resetForTesting("-global1=hello")
-
-	flagGlobal1 := flag.String("global1", "default-global1", "Description about global1")
-	Parse()
-	if *flagGlobal1 != "hello" {
-		t.Errorf("global flag should be set: expected default-global1, found %s", *flagGlobal1)
-	}
-}
-
-// Tests the total number of globally registered flags.
-func TestGlobalFlagsCount(t *testing.T) {
-	resetForTesting("-global1=hello", "-global2=hi")
-
-	flag.String("global1", "default-global1", "Description about global1")
-	flag.String("global2", "default-global2", "Description about global2")
-	Parse()
-
-	total := numOfGlobalFlags(flag.CommandLine)
-	if total != 2 {
-		t.Error("total number of global flags are expected to be 2, found %v", total)
-	}
-}
-
 // Tests if subcommand runs if it's provided as a part of arguments.
 func TestCommand(t *testing.T) {
-	resetForTesting("-global1=hello", "command1")
+	resetForTesting("command1")
 
-	flagGlobal1 := flag.String("global1", "default-global1", "Description about global1")
 	c1 := &testCmd1{}
-	On("command1", "", c1, []string{})
-	Parse()
+	On("command1", "", "", c1)
 	Run()
 	if !c1.run {
 		t.Error("command 'command1' was expected to run, but it didn't")
@@ -72,19 +33,14 @@ func TestCommand(t *testing.T) {
 	if *c1.flag1 {
 		t.Errorf("flag1 should be set to default: expected false, found %v", *c1.flag1)
 	}
-	if *flagGlobal1 != "hello" {
-		t.Errorf("global flag should be set: expected default-global1, found %s", *flagGlobal1)
-	}
 }
 
 // Tests if subcommand runs and subcommand flags are set.
 func TestCommandFlags(t *testing.T) {
-	resetForTesting("-global1=hello", "command1", "-flag1=true")
+	resetForTesting("command1", "-flag1=true")
 
-	flag.String("global1", "default-global1", "Description about global1")
 	c1 := &testCmd1{}
-	On("command1", "", c1, []string{})
-	Parse()
+	On("command1", "", "", c1)
 	Run()
 	if !c1.run {
 		t.Error("command 'command1' was expected to run, but it didn't")
@@ -101,9 +57,8 @@ func TestMultiCommands(t *testing.T) {
 
 	c1 := &testCmd1{}
 	c2 := &testCmd2{}
-	On("command1", "", c1, []string{})
-	On("command2", "", c2, []string{})
-	Parse()
+	On("command1", "", "", c1)
+	On("command2", "", "", c2)
 	Run()
 	if c1.run {
 		t.Error("command 'command1' was not expected to run, but it did")
@@ -113,37 +68,12 @@ func TestMultiCommands(t *testing.T) {
 	}
 }
 
-// Tests if subcommand runnable has run, if Run is not invoked.
-func TestRun(t *testing.T) {
-	resetForTesting("command1")
-
-	c1 := &testCmd1{}
-	On("command1", "", c1, []string{})
-	Parse()
-	if c1.run {
-		t.Error("command 'command1' was not expected to run, but it did")
-	}
-}
-
-func TestAdditionalCommandArgs(t *testing.T) {
-	resetForTesting("command1", "--flag1=true", "somearg")
-
-	c1 := &testCmd1{}
-	On("command1", "", c1, []string{})
-	Parse()
-	//args are no longer kept in a global, instead they are in a commander field.
-	args := CommandLine.(*commander).matchingFlags.Args()
-	if len(args) < 1 || args[0] != "somearg" {
-		t.Error("additional command 'somearg' is expected, but can't be found:", args)
-	}
-}
-
 // Resets os.Args and the default flag set.
 func resetForTesting(args ...string) {
 
 	os.Args = append([]string{"cmd"}, args...)
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	CommandLine = NewCommander(os.Args[0], flag.CommandLine)
+	CommandLine = NewCommander()
 }
 
 // testCmd1 is a test sub command.
@@ -154,9 +84,8 @@ type testCmd1 struct {
 }
 
 // Defines flags for the sub command.
-func (cmd *testCmd1) Flags(fs *flag.FlagSet) *flag.FlagSet {
+func (cmd *testCmd1) Flags(fs *flag.FlagSet) {
 	cmd.flag1 = fs.Bool("flag1", false, "Description about flag1")
-	return fs
 }
 
 // Sets the run flag.
@@ -172,9 +101,8 @@ type testCmd2 struct {
 }
 
 // Defines flags for the sub command.
-func (cmd *testCmd2) Flags(fs *flag.FlagSet) *flag.FlagSet {
+func (cmd *testCmd2) Flags(fs *flag.FlagSet) {
 	cmd.flag2 = fs.Bool("flag2", false, "Description about flag2")
-	return fs
 }
 
 // Sets the run flag.

--- a/command_test.go
+++ b/command_test.go
@@ -51,7 +51,7 @@ func TestGlobalFlagsCount(t *testing.T) {
 	flag.String("global2", "default-global2", "Description about global2")
 	Parse()
 
-	total := numOfGlobalFlags()
+	total := numOfGlobalFlags(flag.CommandLine)
 	if total != 2 {
 		t.Error("total number of global flags are expected to be 2, found %v", total)
 	}
@@ -131,15 +131,19 @@ func TestAdditionalCommandArgs(t *testing.T) {
 	c1 := &testCmd1{}
 	On("command1", "", c1, []string{})
 	Parse()
+	//args are no longer kept in a global, instead they are in a commander field.
+	args := CommandLine.(*commander).matchingFlags.Args()
 	if len(args) < 1 || args[0] != "somearg" {
-		t.Error("additional command 'somearg' is expected, but can't be found")
+		t.Error("additional command 'somearg' is expected, but can't be found:", args)
 	}
 }
 
 // Resets os.Args and the default flag set.
 func resetForTesting(args ...string) {
+
 	os.Args = append([]string{"cmd"}, args...)
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	CommandLine = NewCommander(os.Args[0], flag.CommandLine)
 }
 
 // testCmd1 is a test sub command.

--- a/commander.go
+++ b/commander.go
@@ -1,0 +1,295 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+//Commander can register sub commands and:
+//
+// - print their Usage
+//
+// - Parse flagset to find out subcommands, and required flags
+//
+// - Run the matching subcommand
+//
+// Command implements Cmd.Run([]string) so you can do things like:
+//
+//      type myCmd struct {
+//     	    command.Commander
+//      }
+//
+//		func (c *myCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+//     	   	c.Commander = command.NewCommander("git", fs)
+//     	    c.On("status","Show the working tree status",&GitStatuCmd{}, nil)
+//      	...
+//		}
+//
+// Works out of the box.
+type Commander interface {
+	//Usage print the usage for this commander
+	Usage()
+	// Registers a Cmd for the provided sub-command name. E.g. name is the
+	// `status` in `git status`.
+	On(name, description string, command Cmd, requiredFlags []string)
+	// Parses the flags and leftover arguments to match them with a
+	// sub-command. Evaluate all of the global flags and register
+	// sub-command handlers before calling it. Sub-command handler's
+	// `Run` will be called if there is a match.
+	// A usage with flag defaults will be printed if provided arguments
+	// don't match the configuration.
+	// Global flags are accessible once Parse executes.
+	Parse()
+	// Runs the subcommand's runnable. If there is no subcommand
+	// registered, it silently returns.
+	Run(args []string)
+	//Set Command Name as it should appear in the doc.
+	SetName(name string)
+}
+
+// Execute a Cmd as a main command
+//
+//For example:
+//
+//    Exec(&myCmd{}, os.Args)
+//
+// If you have write a Commander as a Cmd object (to be used recursively) and you want to
+// use it as a main, this method is for you.
+func Exec(cmd Cmd, args []string) {
+	// init the cmd's flagset
+	fs := cmd.Flags(flag.NewFlagSet(args[0], flag.ExitOnError))
+	//and use it to parse the args
+	fs.Parse(args[1:])
+
+	// recursive case: cmd is also a commander,
+	if cmdr, ok := cmd.(Commander); ok {
+		//pass on the name
+		cmdr.SetName(args[0])
+		// let the commander parse the args too, (to find out the actual subcommand)
+		cmdr.Parse()
+	}
+	// in any case, run it
+	cmd.Run(fs.Args())
+}
+
+type commander struct {
+	//a commander is made of:
+	// - its own name (defined from outside using setName)
+	// - the command's flagset (for self options)
+	// - the map of registered subcommands
+	// - the subcommand matched during "parse" stage
+	// - the args (build during parse stage) to be passed to the subcommand
+
+	name  string
+	flags *flag.FlagSet // this command flags
+
+	// A map of all of the registered sub-commands.
+	cmds map[string]*cmdCont
+
+	// Matching subcommand.
+	matchingCmd   *cmdCont
+	matchingFlags *flag.FlagSet
+
+	// Flag to determine whether help is
+	// asked for subcommand or not
+	flagHelp *bool
+}
+
+//NewCommander creates a new Commander. The 'name' is the the subcommand name,
+// and the fs is the Cmd current flagset.
+//
+// A NewCommander is better created in the Flag(fs *flag.FlagSet) method.
+func NewCommander(name string, fs *flag.FlagSet) Commander {
+
+	c := &commander{
+		name:  name,
+		cmds:  make(map[string]*cmdCont),
+		flags: fs,
+	}
+	//a command record the usage to be declared
+	fs.Usage = c.Usage
+	return c
+}
+
+func (c *commander) SetName(name string) { c.name = name }
+
+// Registers a Cmd for the provided sub-command name. E.g. name is the
+// `status` in `git status`.
+func (c *commander) On(name, description string, command Cmd, requiredFlags []string) {
+	c.cmds[name] = &cmdCont{
+		name:          name,
+		desc:          description,
+		command:       command,
+		requiredFlags: requiredFlags,
+	}
+}
+
+// Parses the flags and leftover arguments to match them with a
+// sub-command. Evaluate all of the global flags and register
+// sub-command handlers before calling it. Sub-command handler's
+// `Run` will be called if there is a match.
+// A usage with flag defaults will be printed if provided arguments
+// don't match the configuration.
+// Global flags are accessible once Parse executes.
+func (c *commander) Parse() {
+
+	// if there are no subcommands registered,
+	// return immediately
+	if len(c.cmds) < 1 {
+		return
+	}
+
+	if c.flags.NArg() < 1 {
+		c.flags.Usage()
+		os.Exit(1)
+	}
+
+	name := c.flags.Arg(0)
+
+	if cont, ok := c.cmds[name]; ok { //this is an existing command
+
+		// Init it
+		c.matchingFlags = cont.command.Flags(flag.NewFlagSet(name, flag.ExitOnError))
+		// always append a -h option to print "help"
+		c.flagHelp = c.matchingFlags.Bool("h", false, "")
+		c.matchingFlags.Parse(c.flags.Args()[1:])
+		c.matchingCmd = cont
+
+		// recursive case: if it's also a commander (it has subcommands)
+		if cmdr, ok := cont.command.(Commander); ok {
+			cmdr.SetName(c.name + " " + name)
+			//we had to split setName, and Parse because:
+
+			// checking for required flags might target subCommandUsage (that needs the name to be set)
+			// but this check need to be made before parsing the subcommand
+		}
+
+		// Check for required flags.
+		flagMap := make(map[string]bool)
+		for _, flagName := range cont.requiredFlags {
+			flagMap[flagName] = true
+		}
+		c.matchingFlags.Visit(func(f *flag.Flag) {
+			delete(flagMap, f.Name)
+		})
+		if len(flagMap) > 0 { // missed a required flag
+			c.subcommandUsage(c.matchingCmd)
+			os.Exit(1)
+		}
+
+		// ok this one is good. Now, if this "Cmd" is also a Commander go on parsing
+		if cmdr, ok := cont.command.(Commander); ok {
+			cmdr.Parse() // fs has been parsed
+		}
+
+	} else {
+		c.flags.Usage()
+		os.Exit(1)
+	}
+}
+
+//Implement the Cmd .Run method so that a Commander is almsot a Cmd too.
+// the args is ignored.
+func (c *commander) Run(args []string) {
+	c.Exec()
+}
+
+// Exec the subcommand's runnable. If there is no subcommand
+// registered, it silently returns.
+//args is totally ignored and kept to be
+func (c *commander) Exec() {
+	if c.matchingCmd != nil {
+		if *c.flagHelp {
+			c.subcommandUsage(c.matchingCmd)
+			return
+		}
+		c.matchingCmd.command.Run(c.matchingFlags.Args())
+	}
+}
+
+// Prints the usage.
+func (c *commander) Usage() {
+	name := c.name
+	if len(c.cmds) == 0 {
+		// no subcommands
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", name)
+		c.flags.PrintDefaults()
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Usage: %s <command>\n\n", name)
+	fmt.Fprintf(os.Stderr, "where <command> is one of:\n")
+
+	//Sort conts by name
+	conts := make([]*cmdCont, 0, len(c.cmds))
+	for _, cont := range c.cmds {
+		conts = append(conts, cont)
+	}
+	sort.Stable(byName(conts))
+
+	for _, cont := range conts {
+		fmt.Fprintf(os.Stderr, "  %-15s %s\n", cont.name, cont.desc)
+	}
+
+	if numOfGlobalFlags(c.flags) > 0 {
+		fmt.Fprintf(os.Stderr, "\navailable flags:\n")
+		c.flags.PrintDefaults()
+	}
+	fmt.Fprintf(os.Stderr, "\n%s <command> -h for subcommand help\n", name)
+}
+
+func (c *commander) subcommandUsage(cont *cmdCont) {
+	name := c.name
+	fmt.Fprintf(os.Stderr, "  %s %-15s %s\n", name, cont.name, cont.desc)
+
+	// should only output sub command flags, ignore h flag.
+	fs := cont.command.Flags(flag.NewFlagSet(cont.name, flag.ContinueOnError))
+	if cmdr, ok := cont.command.(Commander); ok {
+		cmdr.SetName(c.name + " " + cont.name)
+	}
+	if fs.Usage != nil { // if the cmd has defined a usage, use it.
+		fs.Usage()
+		return
+	}
+	// else
+	if numOfGlobalFlags(fs) > 0 {
+		fmt.Fprintf(os.Stderr, "Usage %s:\n", cont.name)
+		fs.PrintDefaults()
+	}
+	if len(cont.requiredFlags) > 0 {
+		fmt.Fprintf(os.Stderr, "\nrequired flags:\n")
+		fmt.Fprintf(os.Stderr, "  %s\n\n", strings.Join(cont.requiredFlags, ", "))
+	}
+}
+
+// Returns the total number of registered flags in a flagset.
+func numOfGlobalFlags(fs *flag.FlagSet) (count int) {
+	fs.VisitAll(func(flag *flag.Flag) {
+		count++
+	})
+	return
+}
+
+//byName to sort sub command by their name
+type byName []*cmdCont
+
+func (a byName) Len() int           { return len(a) }
+func (a byName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byName) Less(i, j int) bool { return a[i].name < a[j].name }


### PR DESCRIPTION
The main interface is unchanged, but it is now possible to nest subcommands.

a nested subcommand is also a Cmd, 

this package provides a help object "Commander", that you can use to write your own Cmd with nested subcommands.

for example

type myCmd struct {
        // anonymous field to use Commander.Run() method
        command.Commander
}

func (cmd *myCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
        // to make a nested command, just build a new commander
        cmd.Commander = command.NewCommander("ci", fs)
        // and call the same methods as the usual top level ones
        cmd.On("log", "print remote log", &cicmd.LogCmd{}, nil)
        return fs
}

to avoid duplicating the code, I've also replaced the top level On, Parse, and Run() function to use a Commander.

And I've also updated the Usage() to print subcommand in alphabetical order.
