### PR TITLE
Pr upstream

### DIFF
--- a/command.go
+++ b/command.go
@@ -24,6 +24,10 @@ import (
 	"strings"
 )
 
+var (
+    OutFileDesc = os.Stdout
+)
+
 // A map of all of the registered sub-commands.
 var cmds map[string]*cmdCont = make(map[string]*cmdCont)
 
@@ -70,32 +74,32 @@ func Usage() {
 	program := os.Args[0]
 	if len(cmds) == 0 {
 		// no subcommands
-		fmt.Fprintf(os.Stderr, "Usage of %s:\n", program)
+		fmt.Fprintf(OutFileDesc, "Usage of %s:\n", program)
 		flag.PrintDefaults()
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "Usage: %s <command>\n\n", program)
-	fmt.Fprintf(os.Stderr, "where <command> is one of:\n")
+	fmt.Fprintf(OutFileDesc, "Usage: %s <command>\n\n", program)
+	fmt.Fprintf(OutFileDesc, "where <command> is one of:\n")
 	for name, cont := range cmds {
-		fmt.Fprintf(os.Stderr, "  %-15s %s\n", name, cont.desc)
+		fmt.Fprintf(OutFileDesc, "  %-15s %s\n", name, cont.desc)
 	}
 
 	if numOfGlobalFlags() > 0 {
-		fmt.Fprintf(os.Stderr, "\navailable flags:\n")
+		fmt.Fprintf(OutFileDesc, "\navailable flags:\n")
 		flag.PrintDefaults()
 	}
-	fmt.Fprintf(os.Stderr, "\n%s <command> -h for subcommand help\n", program)
+	fmt.Fprintf(OutFileDesc, "\n%s <command> -h for subcommand help\n", program)
 }
 
 func subcommandUsage(cont *cmdCont) {
-	fmt.Fprintf(os.Stderr, "Usage of %s %s:\n", os.Args[0], cont.name)
+	fmt.Fprintf(OutFileDesc, "Usage of %s %s:\n", os.Args[0], cont.name)
 	// should only output sub command flags, ignore h flag.
 	fs := matchingCmd.command.Flags(flag.NewFlagSet(cont.name, flag.ContinueOnError))
 	fs.PrintDefaults()
 	if len(cont.requiredFlags) > 0 {
-		fmt.Fprintf(os.Stderr, "\nrequired flags:\n")
-		fmt.Fprintf(os.Stderr, "  %s\n\n", strings.Join(cont.requiredFlags, ", "))
+		fmt.Fprintf(OutFileDesc, "\nrequired flags:\n")
+		fmt.Fprintf(OutFileDesc, "  %s\n\n", strings.Join(cont.requiredFlags, ", "))
 	}
 }
 

--- a/command.go
+++ b/command.go
@@ -37,6 +37,8 @@ var args []string
 // asked for subcommand or not
 var flagHelp *bool
 
+var definedHelp *Cmd = nil
+
 // Cmd represents a sub command, allowing to define subcommand
 // flags and runnable to run once arguments match the subcommand
 // requirements.
@@ -105,7 +107,28 @@ func subcommandUsage(cont *cmdCont) {
 // don't match the configuration.
 // Global flags are accessible once Parse executes.
 func Parse() {
+
+	helpCmd := definedHelp
+
+	canCallHelp := true
+
+	if helpCmd == nil {
+		canCallHelp = false
+
+		var helpCmdV *cmdCont
+		helpCmdV, canCallHelp = cmds["help"]
+		if canCallHelp && helpCmdV != nil {
+			helpCmd = &helpCmdV.command
+		}
+	}
+	if canCallHelp {
+		flag.Usage = func() {
+			(*helpCmd).Run(os.Args[2:])
+		}
+	}
+
 	flag.Parse()
+
 	// if there are no subcommands registered,
 	// return immediately
 	if len(cmds) < 1 {
@@ -168,4 +191,8 @@ func numOfGlobalFlags() (count int) {
 		count++
 	})
 	return
+}
+
+func DefineHelp(help Cmd) {
+	definedHelp = &help
 }

--- a/command.go
+++ b/command.go
@@ -21,11 +21,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 )
 
 var (
-    OutFileDesc = os.Stdout
+	OutFileDesc = os.Stdout
 )
 
 // A map of all of the registered sub-commands.
@@ -69,6 +70,20 @@ func On(name, description string, command Cmd, requiredFlags []string) {
 	}
 }
 
+func printUsageSorted(mapping map[string]*cmdCont) {
+	keys := []string{}
+	for key := range mapping {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		cont := mapping[key]
+		fmt.Fprintf(OutFileDesc, "  %-15s %s\n", key, cont.desc)
+	}
+}
+
 // Prints the usage.
 func Usage() {
 	program := os.Args[0]
@@ -81,14 +96,14 @@ func Usage() {
 
 	fmt.Fprintf(OutFileDesc, "Usage: %s <command>\n\n", program)
 	fmt.Fprintf(OutFileDesc, "where <command> is one of:\n")
-	for name, cont := range cmds {
-		fmt.Fprintf(OutFileDesc, "  %-15s %s\n", name, cont.desc)
-	}
+
+	printUsageSorted(cmds)
 
 	if numOfGlobalFlags() > 0 {
 		fmt.Fprintf(OutFileDesc, "\navailable flags:\n")
 		flag.PrintDefaults()
 	}
+
 	fmt.Fprintf(OutFileDesc, "\n%s <command> -h for subcommand help\n", program)
 }
 


### PR DESCRIPTION
This PR provides improvements to the original code:
- help.Usage: 
  - This is necessary to match the behaviour of common
    Unix usage where programs can take:
    `prog -h, prog --help, prog help, prog -help, prog --h`.
    Otherwise fla.Parse exits upon encountering -h, could
    define flag.Usage but we need to maintain the behaviour
    or passing arguments to the help function.
- stdout is now the outfile descriptor instead of stderr:
  This is allow for users to pipe content into filters as well as to search for strings e.g using grep
  `<a_prog_using_command> -h | grep -i keyword [keywords....]`
- help: stable sort order for subcommands:
  Makes the program help output more familiar and more easily indexed without minimal differences
  in case it changes, otherwise everytime there will be changes.
